### PR TITLE
options.cache fix

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -72,7 +72,7 @@ module.exports = function (Hogan) {
 	Hogan.renderFile = function (path, options, fn) {
 		ctx = this;
 		try {
-			var partials = renderPartials(options.partials);
+			var partials = renderPartials(options.partials, options);
 			fn(null, Hogan.fcompile(path,options).render(options,partials));
 		} catch (error) {
 			fn(error);


### PR DESCRIPTION
options.cache for partials was ignored so partials rendering were ignoring express "view cache" settings. It is killing performance on production. opt.partials are ignored so there is no reason for deleting 'partials' from passed options object.
